### PR TITLE
Add hxml discovery

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
       "request": "launch",
       "name": "Launch Build",
       "program": "${workspaceFolder}/bin/wizard.js",
-      "args": ["--build", "./hxml/test.hxml"],
+      "args": ["--build"],
       "preLaunchTask": "haxe: hxml/compile.hxml",
       "console": "integratedTerminal",
       "sourceMaps": true

--- a/scaffold/compile.hxml
+++ b/scaffold/compile.hxml
@@ -1,0 +1,30 @@
+-lib LunaTea
+
+-cp src
+# JS Version 
+-D js-es=6
+
+# Enable/Disable console.log -- tracing with the below line
+# --no-traces
+
+-dce full
+
+# Static Code Analysis For Removing  Unnecessary Code
+-D analyzer-optimize 
+
+# Haxe Source Map
+--debug
+# --no-inline
+# --no-opt
+# -D keep_inline_positions
+
+# RM Version for Conditional Compilation
+# -D compileMV
+
+# Note you can call an hxml file inside an hxml file for build purposes.
+# For Compiling Separate JavaScript Files
+--each
+
+--next
+-js game/js/plugins/Luna_Chapters.js
+-main Main

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -1,3 +1,5 @@
+import prompts.Prompter;
+import wizard.utils.HxmlDiscovery;
 import wizard.Builder;
 import wizard.GuidedSetup;
 import mcli.CommandLine;
@@ -18,11 +20,34 @@ class Main extends CommandLine {
 
   public function build(?hxml: String) {
     // Build from source files
+    if (hxml == null) {
+      var hxmlPaths = HxmlDiscovery.discover();
+      var choices = hxmlPaths.map(path -> {
+        return {
+          title: path,
+          value: path,
+          description: '',
+          disabled: false,
+          selected: false
+        }
+      });
+      Prompter.call({
+        type: 'multiselect',
+        name: 'hxmlPaths',
+        message: 'Choose an hxml to build from',
+        choices: choices
+      }).then((response: Dynamic) -> {
+        var paths: Array<String> = response.hxmlPaths;
+        for (path in paths) {
+          Builder.compileFromSource(path);
+        }
+      });
+      return;
+     }
     Builder.compileFromSource(hxml);
   }
 
   public static function main() {
     new mcli.Dispatch(Sys.args()).dispatch(new Main());
   }
-
 }

--- a/src/wizard/utils/HxmlDiscovery.hx
+++ b/src/wizard/utils/HxmlDiscovery.hx
@@ -1,0 +1,49 @@
+package wizard.utils;
+
+import sys.FileSystem;
+import js.node.Path;
+
+using Lambda;
+
+class HxmlDiscovery {
+  public static function walk(path: String, ?onFile: String->Void, ?onDirectory: String->Void): Array<String> {
+    var result: Array<String> = [];
+    var nodes: Array<String> = FileSystem.readDirectory(path);
+    var ignoreList = ['node_modules', '.git', 'haxe_libraries', '.github'];
+
+    while (nodes.length > 0) {
+      var node = nodes.shift();
+
+      if (ignoreList.contains(node)) {
+        continue;
+      }
+
+      result.push(Path.resolve(path, node));
+
+      if (FileSystem.isDirectory(node)) {
+        if (onDirectory != null) {
+          onDirectory(Path.resolve(path, node));
+        }
+        nodes = nodes.concat(walk(node));
+      } else if (onFile != null) {
+        onFile(Path.resolve(path, node));
+      }
+    }
+    return result;
+  }
+
+  public static function discover(): Array<String> {
+    var discovered: Array<String> = [];
+
+    function onFile(path) {
+      var ereg = new EReg('.hxml', 'g');
+      if (ereg.match(path)) {
+        discovered.push(path);
+      }
+    }
+    Sys.setCwd(Path.resolve('../../'));
+    walk(Sys.getCwd(), onFile);
+
+    return discovered;
+  }
+}

--- a/src/wizard/utils/HxmlDiscovery.hx
+++ b/src/wizard/utils/HxmlDiscovery.hx
@@ -41,7 +41,7 @@ class HxmlDiscovery {
         discovered.push(path);
       }
     }
-    Sys.setCwd(Path.resolve('../../'));
+
     walk(Sys.getCwd(), onFile);
 
     return discovered;

--- a/tests/TestAll.hx
+++ b/tests/TestAll.hx
@@ -7,6 +7,7 @@ class TestAll {
     runner.addCase(new TestBuilder());
     runner.addCase(new TestNodePackage());
     runner.addCase(new TestLixPackage());
+    runner.addCase(new TestHxmlDiscovery());
     Report.create(runner);
     runner.run();
   }

--- a/tests/TestHxmlDiscovery.hx
+++ b/tests/TestHxmlDiscovery.hx
@@ -15,6 +15,7 @@ class TestHxmlDiscovery extends Test {
   }
 
   function testHxmlDsicovery() {
+    Sys.setCwd(Path.resolve('../../'));
     var hxmlFiles = HxmlDiscovery.discover();
     Assert.isTrue(hxmlFiles.length > 0);
   }

--- a/tests/TestHxmlDiscovery.hx
+++ b/tests/TestHxmlDiscovery.hx
@@ -1,0 +1,21 @@
+import wizard.utils.HxmlDiscovery;
+import utest.utils.TestBuilder;
+import js.node.Path;
+import utest.Test;
+import utest.Assert;
+import sys.io.File;
+import sys.FileSystem;
+import utils.FileSystemExt;
+
+using StringTools;
+
+class TestHxmlDiscovery extends Test {
+  function setupClass() {
+    Sys.setCwd(Path.resolve('./'));
+  }
+
+  function testHxmlDsicovery() {
+    var hxmlFiles = HxmlDiscovery.discover();
+    Assert.isTrue(hxmlFiles.length > 0);
+  }
+}


### PR DESCRIPTION
 When running `luna-wizard --build` with no path argument, it will discover .hxml files and prompt you to select files to compile with.
- [x] Adds a basic .hxml file discovery

- [x] Add prompt to build CLI command

- [x] Add basic tests