### PR TITLE
Add compile hxml file to be included in new project

### DIFF
--- a/src/wizard/Builder.hx
+++ b/src/wizard/Builder.hx
@@ -22,6 +22,7 @@ class Builder {
     addGamesDirectory(Sys.getCwd());
     addCheckstyleJson(Sys.getCwd());
     addHaxeFormatJson(Sys.getCwd());
+    addCompileHxml(Sys.getCwd());
   }
 
   public static function addSrcDirectory(path: String) {
@@ -53,6 +54,15 @@ class Builder {
       var fileData: String = File.getContent(jsonPath).toString();
 
       File.write('${path}/hxformat.json', Json.parse(fileData));
+    }
+  }
+
+  public static function addCompileHxml(path: String) {
+    if (!FileSystem.exists('${path}/compile.hxml')) {
+      var jsonPath = '${_scaffoldDir}/compile.hxml';
+      var fileData: String = File.getContent(jsonPath);
+
+      File.saveContent('${path}/compile.hxml', fileData);
     }
   }
 


### PR DESCRIPTION
`compile.hxml` file was included in the scaffold in #9 and this will PR will make sure its added to a new project after the setup wizard has completed.