### PR TITLE
Add multi target napkin

### DIFF
--- a/src/Utils.hx
+++ b/src/Utils.hx
@@ -1,0 +1,10 @@
+class Utils {
+  public static function getMatches(ereg: EReg, input: String, index: Int = 0): Array<String> {
+    var matches = [];
+    while (ereg.match(input)) {
+      matches.push(ereg.matched(index));
+      input = ereg.matchedRight();
+    }
+    return matches;
+  }
+}

--- a/src/wizard/Builder.hx
+++ b/src/wizard/Builder.hx
@@ -10,7 +10,7 @@ using StringTools;
 class Builder {
   public static var path: String = Sys.getCwd();
   public static var programDir = Path.dirname(Sys.programPath());
-  private static var _scaffoldDir = '${Path.dirname(programDir)}/scaffold'; 
+  private static var _scaffoldDir = '${Path.dirname(programDir)}/scaffold';
 
   public static function newProject(?path: String) {
     if (path != null && path != '') {
@@ -88,11 +88,15 @@ class Builder {
     } else {
       var hxmlData = File.getContent(hxmlPath);
       var ereg = new EReg('(-js|--js)(.*)', 'g');
-      if (ereg.match(hxmlData)) {
-        var jsTargetPath = ereg.matched(2).trim();
-        var code = File.getContent(Path.resolve(jsTargetPath));
+      var matches = Utils.getMatches(ereg, hxmlData, 2);
+      var jsTargetPaths = matches.map((path: String )-> {
+        return path.trim();
+      });
+
+      for (path in jsTargetPaths) {
+        var code = File.getContent(Path.resolve(path));
         try {
-          File.saveContent(jsTargetPath, Napkin.parse(code, usePrettier));
+          File.saveContent(path, Napkin.parse(code, usePrettier));
         } catch (error) {
           trace(error.message);
         }


### PR DESCRIPTION
When using the build command, the napkin parser is only run on the first js target path it finds, this PR will allow multiple js target paths to be cleaned using the napkin parser.
